### PR TITLE
Provide values for all arguments in http_build_query

### DIFF
--- a/lib/RetailCrm/Http/Client.php
+++ b/lib/RetailCrm/Http/Client.php
@@ -61,7 +61,7 @@ class Client
         $path = $this->url . $path;
 
         if (self::METHOD_GET === $method && sizeof($parameters)) {
-            $path .= '?' . http_build_query($parameters);
+            $path .= '?' . http_build_query($parameters, '', '&');
         }
 
         $ch = curl_init();


### PR DESCRIPTION
Without that http_build_query depend on system settings and may fail
(drupal 6 in default config)
