### PR TITLE
FIX

### DIFF
--- a/lib/RetailCrm/Methods/V3/Telephony.php
+++ b/lib/RetailCrm/Methods/V3/Telephony.php
@@ -69,7 +69,7 @@ trait Telephony
         $phone,
         $type,
         $codes,
-        $hangupStatus,
+        $hangupStatus = null,
         $externalPhone = null,
         $webAnalyticsData = []
     ) {

--- a/lib/RetailCrm/Response/ApiResponse.php
+++ b/lib/RetailCrm/Response/ApiResponse.php
@@ -190,4 +190,15 @@ class ApiResponse implements \ArrayAccess
 
         return $this->response[$offset];
     }
+
+    /**
+     * Get response
+     *
+     * @return array
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
 }


### PR DESCRIPTION
hangupstatus параметр который нужен только при определённых условиях, описания метода: https://help.retailcrm.ru/Developers/ApiVersion5#post--api-v5-telephony-call-event
В случае, если type равен ​hangup​, то в поле hangupStatus можно передать статус.