### PR TITLE
Add orders merge technique

### DIFF
--- a/lib/RetailCrm/Methods/V5/Orders.php
+++ b/lib/RetailCrm/Methods/V5/Orders.php
@@ -42,7 +42,7 @@ trait Orders
      */
     public function ordersCombine($order, $resultOrder, $technique = 'ours')
     {
-        $techniques = ['ours', 'summ', 'theirs'];
+        $techniques = ['ours', 'summ', 'theirs', 'merge'];
 
         if (!count($order) || !count($resultOrder)) {
             throw new \InvalidArgumentException(


### PR DESCRIPTION
RetailCRM documentation [describes](https://help.retailcrm.pro/Developers/ApiVersion5#post--api-v5-orders-combine) orders combine technique called `merge`, but API client doesn't support it.

This PR adds that technique.