### PR TITLE
Исправлено исключение в методе fileDownload

### DIFF
--- a/lib/RetailCrm/Http/Client.php
+++ b/lib/RetailCrm/Http/Client.php
@@ -73,7 +73,7 @@ class Client
      * @throws CurlException
      * @throws InvalidJsonException
      *
-     * @return ApiResponse
+     * @return ApiResponse|string
      */
     public function makeRequest(
         $path,
@@ -139,6 +139,10 @@ class Client
 
         if ($errno) {
             throw new CurlException($error, $errno);
+        }
+
+        if (strpos($path, '/download') !== false) {
+            return $responseBody;
         }
 
         return new ApiResponse($statusCode, $responseBody);

--- a/lib/RetailCrm/Methods/V5/Files.php
+++ b/lib/RetailCrm/Methods/V5/Files.php
@@ -145,7 +145,7 @@ trait Files
      * @throws \RetailCrm\Exception\CurlException
      * @throws \RetailCrm\Exception\InvalidJsonException
      *
-     * @return \RetailCrm\Response\ApiResponse
+     * @return string
      */
     public function fileDownload($id)
     {


### PR DESCRIPTION
Ранее метод падал с исключением `Uncaught RetailCrm\Exception\InvalidJsonException: Invalid JSON in the API response body`, т.к. `/api/v5/files/{id}/download` возвращает не json