### PR TITLE
fix incorrect composer.json patching

### DIFF
--- a/src/Component/ComposerLocator.php
+++ b/src/Component/ComposerLocator.php
@@ -61,7 +61,7 @@ class ComposerLocator
             $fileName = implode(DIRECTORY_SEPARATOR, [$dir, 'composer.json']);
 
             if (file_exists($fileName) && static::getPackageComposerJson() !== $fileName) {
-                return $dir . '/composer.json';
+                return $fileName;
             }
 
             $counter++;

--- a/src/Component/ComposerLocator.php
+++ b/src/Component/ComposerLocator.php
@@ -58,7 +58,9 @@ class ComposerLocator
         $dir = static::getBaseDirectory();
 
         for (;;) {
-            if (file_exists($dir . '/composer.json')) {
+            $fileName = implode(DIRECTORY_SEPARATOR, [$dir, 'composer.json']);
+
+            if (file_exists($fileName) && static::getPackageComposerJson() !== $fileName) {
                 return $dir . '/composer.json';
             }
 
@@ -79,5 +81,15 @@ class ComposerLocator
     private static function getBaseDirectory(): string
     {
         return (string) realpath(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..']));
+    }
+
+    /**
+     * Returns full path to the composer.json of this package.
+     *
+     * @return string
+     */
+    private static function getPackageComposerJson(): string
+    {
+        return (string) realpath(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'composer.json']));
     }
 }

--- a/tests/src/Command/CompilerPromptCommandTest.php
+++ b/tests/src/Command/CompilerPromptCommandTest.php
@@ -23,6 +23,37 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class CompilerPromptCommandTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        $packageComposerJson = implode(DIRECTORY_SEPARATOR, [static::getBaseDirectory(), 'composer.json']);
+        $fileName = implode(DIRECTORY_SEPARATOR, [static::getBaseDirectory(), '..', 'composer.json']);
+
+        if (!file_exists($packageComposerJson)) {
+            self::fail(sprintf('%s does not exist which should not happen at all. Aborting.', $packageComposerJson));
+        }
+
+        if (
+            file_exists(($fileName)) &&
+            (
+                filesize($fileName) !== filesize($packageComposerJson) ||
+                md5_file($fileName) !== md5_file($packageComposerJson)
+            )
+        ) {
+            self::fail(sprintf('%s exists, cannot proceed with tests.', (string) realpath($fileName)));
+        }
+
+        copy($packageComposerJson, $fileName);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $fileName = implode(DIRECTORY_SEPARATOR, [static::getBaseDirectory(), '..', 'composer.json']);
+
+        if (file_exists(($fileName))) {
+            unlink($fileName);
+        }
+    }
+
     public function testDeactivate(): void
     {
         $tester = new CommandTester(new CompilerPromptCommand());
@@ -66,5 +97,13 @@ class CompilerPromptCommandTest extends TestCase
         }
 
         return json_decode((string) file_get_contents($composerJson), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return string
+     */
+    private static function getBaseDirectory(): string
+    {
+        return (string) realpath(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', '..']));
     }
 }

--- a/tests/src/Component/ComposerLocatorTest.php
+++ b/tests/src/Component/ComposerLocatorTest.php
@@ -32,7 +32,6 @@ class ComposerLocatorTest extends TestCase
     {
         $file = ComposerLocator::findComposerJson();
 
-        self::assertStringContainsString('composer.json', $file);
-        self::assertFileExists($file);
+        self::assertEmpty($file);
     }
 }


### PR DESCRIPTION
Inside real project ComposerLocator::findComposerJson() returns the path to the library's composer.json, not the project one. As a result, the compile:prompt command doesn't work properly, it modifies the library's composer.json in the vendor directory instead.

This PR fixes that.