### PR TITLE
Add `isError` and `isPreprocessing` fields to delivery status

### DIFF
--- a/src/Model/Entity/Integration/Delivery/Status.php
+++ b/src/Model/Entity/Integration/Delivery/Status.php
@@ -42,4 +42,20 @@ class Status
      * @JMS\SerializedName("isEditable")
      */
     public $isEditable;
+
+    /**
+     * @var bool
+     *
+     * @JMS\Type("bool")
+     * @JMS\SerializedName("isError")
+     */
+    public $isError;
+
+    /**
+     * @var bool
+     *
+     * @JMS\Type("bool")
+     * @JMS\SerializedName("isPreprocessing")
+     */
+    public $isPreprocessing;
 }

--- a/tests/src/Model/Entity/Integration/Delivery/StatusTest.php
+++ b/tests/src/Model/Entity/Integration/Delivery/StatusTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace RetailCrm\Tests\Model\Entity\Integration\Delivery;
+
+use PHPUnit\Framework\TestCase;
+use RetailCrm\Api\Factory\SerializerFactory;
+use RetailCrm\Api\Model\Entity\Integration\Delivery\Status;
+
+class StatusTest extends TestCase
+{
+    public function testDeserialize(): void
+    {
+        $status = SerializerFactory::create()->fromArray([
+            'code' => 'statusCode',
+            'name' => 'statusName',
+            'isEditable' => true,
+            'isError' => false,
+            'isPreprocessing' => true,
+        ], Status::class);
+
+        self::assertInstanceOf(Status::class, $status);
+        self::assertEquals('statusCode', $status->code);
+        self::assertEquals('statusName', $status->name);
+        self::assertTrue($status->isEditable);
+        self::assertFalse($status->isError);
+        self::assertTrue($status->isPreprocessing);
+    }
+}


### PR DESCRIPTION
Статус ("isError": true) сигнализирует о наличии проблем в процессе доставки. При попадании в этот статус менеджеру будет отправлено оповещение
Статус ("isPreprocessing": true) указывает, что доставка находится в процессе оформления и любые изменения с заказом не желательны. Данный флаг может быть необходим для интеграций, где оформление доставки выполняется в асинхронном режиме